### PR TITLE
refactor: Use new Stripe libraries

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -42,7 +42,6 @@ module.exports = {
       },
     },
     `gatsby-transformer-sharp`,
-    `gatsby-plugin-stripe`,
     `gatsby-plugin-react-helmet`,
   ],
 };

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\""
   },
   "dependencies": {
+    "@stripe/react-stripe-js": "1.0.0-beta.3",
+    "@stripe/stripe-js": "1.0.0-beta.4",
     "apollo-datasource-graphql": "1.3.2",
     "apollo-datasource-rest": "^0.6.9",
     "apollo-server-lambda": "2.9.12",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "gatsby-plugin-react-helmet": "^3.1.18",
     "gatsby-plugin-react-svg": "3.0.0",
     "gatsby-plugin-sharp": "^2.3.3",
-    "gatsby-plugin-stripe": "1.2.3",
     "gatsby-source-filesystem": "^2.1.42",
     "gatsby-source-graphql": "2.1.20",
     "gatsby-source-printful": "1.2.0",
@@ -38,7 +37,6 @@
     "react-dom": "16.10.2",
     "react-helmet": "^5.2.1",
     "react-hook-form": "4.5.6",
-    "react-stripe-elements": "6.0.1",
     "react-toastify": "^5.4.1",
     "react-use-cart": "1.2.2",
     "stripe": "^7.14.0"

--- a/src/components/Checkout.js
+++ b/src/components/Checkout.js
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { useCart } from 'react-use-cart';
 import { navigate } from 'gatsby';
-import { Elements } from 'react-stripe-elements';
 
 import { CheckoutProvider } from '../context/Checkout';
 import CheckoutForm from '../components/CheckoutForm';
@@ -23,20 +22,18 @@ function Checkout() {
   if (isEmpty) return <p>Your cart is empty</p>;
 
   return (
-    <Elements>
-      <CheckoutProvider>
-        <div className="lg:flex -mx-4">
-          <div className="lg:w-1/2 lg:w-2/5 px-4 order-last">
-            <div className="lg:sticky lg:top-0">
-              <CheckoutItemList />
-            </div>
-          </div>
-          <div className="lg:w-1/2 lg:w-3/5 px-4 order-first">
-            <CheckoutForm />
+    <CheckoutProvider>
+      <div className="lg:flex -mx-4">
+        <div className="lg:w-1/2 lg:w-2/5 px-4 order-last">
+          <div className="lg:sticky lg:top-0">
+            <CheckoutItemList />
           </div>
         </div>
-      </CheckoutProvider>
-    </Elements>
+        <div className="lg:w-1/2 lg:w-3/5 px-4 order-first">
+          <CheckoutForm />
+        </div>
+      </div>
+    </CheckoutProvider>
   );
 }
 

--- a/src/components/CheckoutForm/CheckoutForm.js
+++ b/src/components/CheckoutForm/CheckoutForm.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { navigate } from 'gatsby';
 import { useForm, FormContext } from 'react-hook-form';
 import { useMutation } from 'graphql-hooks';
-import { injectStripe } from 'react-stripe-elements';
+import { useStripe, useElements } from '@stripe/react-stripe-js';
 import { useCart } from 'react-use-cart';
 import { toast } from 'react-toastify';
 
@@ -35,7 +35,7 @@ const PAYMENT_INTENT_MUTATION = `mutation createPaymentIntent($input: PaymentInt
   }
 }`;
 
-function CheckoutForm({ elements, stripe }) {
+function CheckoutForm() {
   const methods = useForm({
     defaultValues: {
       separateBilling: false,
@@ -63,6 +63,8 @@ function CheckoutForm({ elements, stripe }) {
     updateShipping,
     updateTax,
   } = useContext(CheckoutContext);
+  const stripe = useStripe();
+  const elements = useElements();
 
   const useSeparateBilling = !!separateBilling;
 
@@ -195,4 +197,4 @@ function CheckoutForm({ elements, stripe }) {
   );
 }
 
-export default injectStripe(CheckoutForm);
+export default CheckoutForm;

--- a/src/components/CheckoutForm/PaymentForm.js
+++ b/src/components/CheckoutForm/PaymentForm.js
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect } from 'react';
 import { useFormContext, ErrorMessage } from 'react-hook-form';
-import { CardElement } from 'react-stripe-elements';
+import { CardElement } from '@stripe/react-stripe-js';
 import classnames from 'classnames';
 
 import LoadingSVG from '../../svg/loading.svg';
@@ -53,7 +53,7 @@ function PaymentForm() {
           <div className="mb-3 md:mb-6">
             <CardElement
               className="appearance-none bg-white border-2 border-gainsboro px-4 py-3 pr-8 focus:outline-none focus:border-slategray focus:bg-white text-slategray focus:outline-none w-full rounded-lg"
-              hidePostalCode={true}
+              options={{ hidePostalCode: true }}
               disabled={checkoutProcessing}
               onChange={handleStripeChange}
               onReady={el => setValue('cardElement', el)}

--- a/src/components/StripeProvider.js
+++ b/src/components/StripeProvider.js
@@ -1,20 +1,11 @@
-import React, { useEffect, useState } from 'react';
-import { StripeProvider as Stripe } from 'react-stripe-elements';
+import React from 'react';
+import { Elements } from '@stripe/react-stripe-js';
+import { loadStripe } from '@stripe/stripe-js';
 
 function StripeProvider({ children }) {
-  const [stripe, setStripe] = useState(null);
+  const stripePromise = loadStripe(process.env.GATSBY_STRIPE_PUBLISHABLE_KEY);
 
-  useEffect(() => {
-    if (window.Stripe) {
-      setStripe(window.Stripe(process.env.GATSBY_STRIPE_PUBLISHABLE_KEY));
-    } else {
-      document.querySelector('#stripe-js').addEventListener('load', () => {
-        setStripe(window.Stripe(process.env.GATSBY_STRIPE_PUBLISHABLE_KEY));
-      });
-    }
-  }, []);
-
-  return <Stripe stripe={stripe}>{children}</Stripe>;
+  return <Elements stripe={stripePromise}>{children}</Elements>;
 }
 
 export default StripeProvider;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1311,6 +1311,18 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
+"@stripe/react-stripe-js@1.0.0-beta.3":
+  version "1.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@stripe/react-stripe-js/-/react-stripe-js-1.0.0-beta.3.tgz#1d07c3d4bc2feaa1dc3580852559057afc6383d4"
+  integrity sha512-5GaKixgvG6lh+R1RGAjR5FyiwzOE4QjSYtdC85O1+VZ0ny4pTtKxX1u3aOwCjKFzGcwvVbFdd/P4qstIAypk+Q==
+  dependencies:
+    prop-types "^15.7.2"
+
+"@stripe/stripe-js@1.0.0-beta.4":
+  version "1.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.0.0-beta.4.tgz#7974474816949b264f3881e01abec0167a46cd7a"
+  integrity sha512-fpjXzOEqp4Xs5rmNOpLTb//jr/4R6wmyzhtSZ++ePBzB5ucnt656zeb6iCvG+xJQaVCgngeTs7+Ig2ACroaHsw==
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6086,11 +6086,6 @@ gatsby-plugin-sharp@^2.3.3:
     svgo "1.3.2"
     uuid "^3.3.3"
 
-gatsby-plugin-stripe@1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-stripe/-/gatsby-plugin-stripe-1.2.3.tgz#bac761bb6ecc6ac4ddd6274537418a5cffa560e8"
-  integrity sha512-iE+6HiiHFG6XdQQh4qBRCuR/PfdN1vZ1XhhCueeUAbZ5mCY0KH0hgoOFJEFNAtCGFAFmeUWBRhMSYnBE3pjFFw==
-
 gatsby-react-router-scroll@^2.1.19:
   version "2.1.19"
   resolved "https://registry.yarnpkg.com/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.19.tgz#4bac8cb5aaba5e2ad6b589a3d289d39257c3b5da"
@@ -10859,7 +10854,7 @@ prompts@^2.3.0:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
 
-prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -11183,13 +11178,6 @@ react-side-effect@^1.1.0:
   integrity sha512-v1ht1aHg5k/thv56DRcjw+WtojuuDHFUgGfc+bFHOWsF4ZK6C2V57DO0Or0GPsg6+LSTE0M6Ry/gfzhzSwbc5w==
   dependencies:
     shallowequal "^1.0.1"
-
-react-stripe-elements@6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/react-stripe-elements/-/react-stripe-elements-6.0.1.tgz#f2b1e4c132cb18f140668556a5218e3b8e082794"
-  integrity sha512-WVKTunSgsrkm8Tv1+BEehfYrA2CHdlk01ocmbcECliPb1EDybaoUCx2MR212ptRHyitMrHF+ahUTewjaX98kcQ==
-  dependencies:
-    prop-types "15.7.2"
 
 react-toastify@^5.4.1:
   version "5.4.1"


### PR DESCRIPTION
Refactor the Stripe implementation to use the new [`@stripe/stripe-js`](https://github.com/stripe/stripe-js) and [`@stripe/react-stripe-js`](https://github.com/stripe/react-stripe-js) libraries.