### PR TITLE
refactor: Ensure consistent locale path

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -24,13 +24,16 @@ const query = graphql`
   }
 `;
 
-function Header() {
+function Header({ pathname }) {
   const {
     cms: { categories, collections },
   } = useStaticQuery(query);
+  const { isEmpty } = useCart();
   const { activeLocale, updateLocale } = useContext(LocaleContext);
 
-  const { isEmpty } = useCart();
+  const showLocaleSwitch = !['/cart', '/checkout', '/success'].includes(
+    pathname
+  );
 
   return (
     <header className="px-6 container mx-auto bg-white w-full block flex-grow flex items-center w-auto justify-between">
@@ -90,28 +93,30 @@ function Header() {
           </ul>
 
           <div className="flex items-center">
-            <div className="relative">
-              <select
-                value={activeLocale}
-                className="block appearance-none bg-white border-none px-4 py-0 pr-8 focus:outline-none focus:bg-white text-lightgray focus:text-slategray rounded-lg"
-                onChange={({ target: { value } }) => updateLocale(value)}
-              >
-                {locales.map(({ label, path }, index) => (
-                  <option key={index} value={path}>
-                    {label}
-                  </option>
-                ))}
-              </select>
-              <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-4 text-lightgray">
-                <svg
-                  className="fill-current h-4 w-4"
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 20 20"
+            {showLocaleSwitch && (
+              <div className="relative">
+                <select
+                  value={activeLocale}
+                  className="block appearance-none bg-white border-none px-4 py-0 pr-8 focus:outline-none focus:bg-white text-lightgray focus:text-slategray rounded-lg"
+                  onChange={({ target: { value } }) => updateLocale(value)}
                 >
-                  <path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" />
-                </svg>
+                  {locales.map(({ label, path }, index) => (
+                    <option key={index} value={path}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+                <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-4 text-lightgray">
+                  <svg
+                    className="fill-current h-4 w-4"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                  >
+                    <path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" />
+                  </svg>
+                </div>
               </div>
-            </div>
+            )}
 
             <div className="ml-4">
               <Link to="/cart" className="flex items-center relative">

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -16,7 +16,7 @@ function Layout({ children, location, pageContext: { locale } }) {
       <LocaleProvider locale={locale} location={location}>
         <Banner />
 
-        <Header />
+        <Header {...location} />
 
         <div className="container mx-auto p-6 md:py-12 lg:py-16">
           {children}

--- a/src/context/Locale.js
+++ b/src/context/Locale.js
@@ -22,7 +22,11 @@ function reducer(state, { type, locale }) {
 
 const defaultLocale = locales.find(locale => locale.default);
 
-function LocaleProvider({ children, locale = defaultLocale.path, location }) {
+function LocaleProvider({
+  children,
+  locale = defaultLocale.path,
+  location: { pathname, search },
+}) {
   const [savedLocale, saveLocale] = useLocalStorage(
     'graphcms-swag-store',
     JSON.stringify({
@@ -35,16 +39,9 @@ function LocaleProvider({ children, locale = defaultLocale.path, location }) {
     locale => {
       dispatch({ type: 'UPDATE_LOCALE', locale });
 
-      if (['/cart', '/checkout', '/success'].includes(location.pathname))
-        return;
-
-      navigate(
-        `/${locale.toLowerCase()}${location.pathname.substring(3)}${
-          location.search
-        }`
-      );
+      navigate(`/${locale.toLowerCase()}${pathname.substring(3)}${search}`);
     },
-    [location.pathname, location.search]
+    [pathname, search]
   );
 
   useEffect(() => {

--- a/src/context/Locale.js
+++ b/src/context/Locale.js
@@ -1,9 +1,4 @@
-import React, {
-  createContext,
-  useCallback,
-  useEffect,
-  useReducer,
-} from 'react';
+import React, { createContext, useEffect, useReducer } from 'react';
 import { navigate } from '@reach/router';
 
 import locales from '../../config/locales';
@@ -34,15 +29,18 @@ function LocaleProvider({
     })
   );
   const [state, dispatch] = useReducer(reducer, JSON.parse(savedLocale));
+  const [, localePath] = pathname.split('/');
 
-  const updateLocale = useCallback(
-    locale => {
-      dispatch({ type: 'UPDATE_LOCALE', locale });
+  const updateLocale = locale =>
+    navigate(`/${locale.toLowerCase()}${pathname.substring(3)}${search}`);
 
-      navigate(`/${locale.toLowerCase()}${pathname.substring(3)}${search}`);
-    },
-    [pathname, search]
-  );
+  useEffect(() => {
+    if (
+      localePath !== state.activeLocale &&
+      locales.map(({ path }) => path).includes(localePath)
+    )
+      dispatch({ type: 'UPDATE_LOCALE', locale: localePath });
+  }, [localePath, state.activeLocale]);
 
   useEffect(() => {
     saveLocale(JSON.stringify(state));


### PR DESCRIPTION
This PR addresses an issue where navigating to a localised page (i.e. `/en/products/ck3oqti2stn5o0b20ogmpwxer`) would not update the active locale value in state. As a result, subsequent navigations throughout app would defer to the old value. This may provide a jarring experience as you jump between DE and EN localised pages.